### PR TITLE
feat(crypto): Add method to make rng secure.

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,36 @@
+//! This module is mostly reexports of sodiumoxide.
+
+use errors::{WhisperResult, WhisperError};
+use sodiumoxide;
+use sodiumoxide::crypto::box_::gen_keypair;
+
+pub use sodiumoxide::crypto::box_::{PublicKey, SecretKey};
+/// A keypair. This is just a helper type.
+#[derive(Debug, Clone)]
+pub struct KeyPair {
+    /// Public key.
+    pub public_key: PublicKey,
+    /// Secret key.
+    pub secret_key: SecretKey,
+}
+impl KeyPair {
+    /// Generate new keypair using libsodium.
+    #[inline]
+    pub fn new() -> KeyPair {
+        let (public_key, secret_key) = gen_keypair();
+        KeyPair {
+            secret_key: secret_key,
+            public_key: public_key,
+        }
+    }
+}
+
+/// In order to make libsodium threadsafe you must call this function before using any of it's andom number generation functions.
+/// It's safe to call this method more than once and from more than one thread.
+pub fn init() -> WhisperResult<()> {
+  if sodiumoxide::init() {
+    Ok(())
+  } else {
+    Err(WhisperError::InitializationFailed)
+  }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,6 +32,9 @@ quick_error! {
         BadFrame {}
         /// Trying to use expired session.
         ExpiredSession {}
+        /// Initialization of libsodium failed.
+        /// This might happen when machine just booted and doesn't have enough entropy.
+        InitializationFailed {}
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,3 +41,4 @@ extern crate nom;
 pub mod session;
 pub mod frame;
 pub mod errors;
+pub mod crypto;


### PR DESCRIPTION
Libsodium has to initiallized to be threadsafe. Moved all crypto into it's own module and reexport
important bits of libsodium.

KeyPair is now part of crypto mod.